### PR TITLE
Set RetentionPolicy=RUNTIME for translated annotation classes.

### DIFF
--- a/CSharpTranslator/src/CS2JTranslator/CS2JMain/Templates.cs
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JMain/Templates.cs
@@ -128,6 +128,7 @@ statement(statement) ::= <<
 
 annotation(modifiers, comments, attributes, name, body) ::= <<
 <comments; separator=""\n"">
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 <modifiers>@interface <name>
 {
     <body>


### PR DESCRIPTION
Example Java translation of C# GlobalObjectiveScope attribute class:

```
@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
public @interface GlobalObjectiveScope
{
}
```