### PR TITLE
nullable support (for swagger)

### DIFF
--- a/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
@@ -479,53 +479,6 @@ namespace Twiglet.CS2J.Translator
         }
 
 
-       // Verify the signature of an XML file against an asymmetric 
-       // algorithm and return the result.
-       public static Boolean VerifyXml(XmlDocument Doc, RSA Key)
-       {
-          // Check arguments.
-          if (Doc == null)
-             throw new ArgumentException("Doc");
-          if (Key == null)
-             throw new ArgumentException("Key");
-			
-          // Add the namespace.
-          XmlNamespaceManager nsmgr = new XmlNamespaceManager(Doc.NameTable);
-          nsmgr.AddNamespace("ss", "http://www.w3.org/2000/09/xmldsig#");
-
-          XmlNode root = Doc.DocumentElement;
-          XmlNodeList nodeList = root.SelectNodes("/*/ss:Signature", nsmgr);
-          // fail if no signature was found.
-          if (nodeList.Count != 1)
-          {
-             return false;
-          }
-
-          // Create a new SignedXml object and pass it
-          // the XML document class.
-          SignedXml signedXml = new SignedXml(Doc);
-
-
-          // Load the first <signature> node.  
-          signedXml.LoadXml((XmlElement)nodeList[0]);
-
-          // Check the signature and return the result.
-          return signedXml.CheckSignature(Key);
-       }
-
-        // Here's where we do the real work...
-        public static void addNetSchema(string fullName)
-        {
-           try
-           {
-              TypeRepTemplate.TemplateReaderSettings.Schemas.Add("urn:www.twigletsoftware.com:schemas:txtemplate:1:0", fullName);
-           }
-           catch (Exception e)
-           {
-              Console.Error.WriteLine("{0} error: {1}", fullName, e.Message);
-           }
-        }
-
         // Here's where we do the real work...
         public static void addNetTranslation(string fullName)
         {

--- a/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
@@ -499,7 +499,7 @@ namespace Twiglet.CS2J.Translator
                    AppEnv.Add(txKey, t);
                 }
             } catch (Exception e) {
-                Console.WriteLine ("WARNING -- Could not import " + fullName + " (" + e.Message + ")");
+                throw new Exception("Could not import " + fullName + " (" + e.Message + ")" + Environment.NewLine + e);
             }
         }
 

--- a/CSharpTranslator/src/CS2JTranslator/CS2JTemplate/TranslationTemplate.cs
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JTemplate/TranslationTemplate.cs
@@ -2592,11 +2592,17 @@ namespace Twiglet.CS2J.Translator.TypeRep
       {
          object o = null;
 	
-         // Create the XmlReader object.
-         // XmlReader reader = XmlReader.Create(fs, TemplateReaderSettings);
-		
          XmlSerializer serializer = new XmlSerializer (t, Constants.TranslationTemplateNamespace);
-         //o = serializer.Deserialize (reader);
+         serializer.UnknownNode += (Object sender, XmlNodeEventArgs args) =>
+         {
+             if (args.Name == "Signature")
+             {
+                 // signature is present in many definitions, but not "expected"
+                 return;
+             }
+             throw new Exception("Parse Failed, line: " + args.LineNumber + " unexpected node: " + args.Name);
+         };
+
          o = serializer.Deserialize (fs);
          return o;
       }


### PR DESCRIPTION
Mainly this change is about adding nullable support, and the portion that's in this PR https://github.com/RusticiSoftware/cs2j/commit/81a3e8cddcf5f73c8b4c36839c492333841fe10b is specifically about treating eg: `int?` as `Nullable<int>`, when it occurs in a method signature.

This is important for Swagger support, since it generates plenty of signatures like:
```
SettingSchema GetCourseConfigurationSetting(NancyContext context, string courseId, string settingId, int? version);
```

I could have added a post-proceessor to our Swagger generation process, but this seemed (a bit) cleaner as there is really nothing special about the generated Swagger code, CS2J ideally should just be able to understand it.

https://github.com/RusticiSoftware/cs2j/commit/89139cf0cdcbbb03b09dcb79c1052b72965172b0 is self explanatory

https://github.com/RusticiSoftware/cs2j/commit/8c86351b6a9eea89678be7afc982b0c6539a4c6a is because I was banging my head against a wall trying to figure out why my template wasn't working (different PR) but I had mistakenly declared a class as an interface and CS2J was silently ignoring my `constructor` definitions. This change should reduce "why doesn't that work" movements when adding templates.

Testing: my test "nullable" code translates as expected, Java Engine still builds.